### PR TITLE
更新guidance中*nix的部分命令，避免遗漏参数导致编译错误

### DIFF
--- a/contents/chapter_guidance.tex
+++ b/contents/chapter_guidance.tex
@@ -84,8 +84,8 @@ cuzthesis.tex为主文档，其设计和规划了论文的整体框架，通过�
     播和接收此脚本，以防范DOS脚本的潜在风险。}
     \item Linux或macOS：在终端中运行
         \begin{itemize}
-            \item \verb|./run.sh xa|：获得全编译后的PDF文档
-            \item \verb|./run.sh x|：快速编译模式
+            \item \verb|./run.sh xa <filename>|：获得全编译后的PDF文档
+            \item \verb|./run.sh x <filename>|：快速编译模式
         \end{itemize}
     \item 全编译指运行\verb|xelatex+bibtex+xelatex+xelatex|以正确生成所有的引用
     链接，如目录，参考文献及引用等。在写作过程中若无添加新的引用，则可用快速编


### PR DESCRIPTION
直接运行./run.sh xa会导致潜在编译错文件的问题，如只编译cuzproposal.tex且产生稀奇古怪的报错。如下图1、2。
<img width="180" alt="image" src="https://user-images.githubusercontent.com/21039254/164966703-6eb62d7c-a62e-472e-9e35-9f367b86a8d9.png">

<img width="562" alt="image" src="https://user-images.githubusercontent.com/21039254/164966738-db5619ed-572f-480c-a74f-879cd0721621.png">
